### PR TITLE
Implement alt exercises

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@ const Typewriter = ({ text, speed = 30 }) => {
 const BBSHeader = ({ operator, onNav }) => (
   <div className="border-2 border-green-500 p-2 font-mono text-green-400 bg-black">
     <div className="flex justify-between items-center border-b-2 border-green-500 pb-1 mb-1">
-      <h1 className="text-lg md:text-xl font-bold">[A.E.G.I.S] PROTOCOL v1.4</h1>
+      <h1 className="text-lg md:text-xl font-bold">[A.E.G.I.S] PROTOCOL v1.5</h1>
       <div className="text-xs text-right">
         <div>OPERATOR ID: {operator.id}</div>
         <div>SYS. INTEGRITY: {operator.systemIntegrity}</div>
@@ -499,7 +499,7 @@ function App() {
               <p><Typewriter text="CONNECTING TO [A.E.G.I.S] NODE 7..." /></p>
               <p><Typewriter text="ENCRYPTION HANDSHAKE... OK" /></p>
               <p><Typewriter text="BIOMETRIC SYNC... OK" /></p>
-              <p className="text-sm mt-2">AEGIS PROTOCOL v1.4</p>
+              <p className="text-sm mt-2">AEGIS PROTOCOL v1.5</p>
           </div>
       )
   }
@@ -512,7 +512,7 @@ function App() {
                 {renderScreen()}
             </main>
             <footer className="border-t-2 border-green-500 p-1 text-center text-xs text-green-500">
-                <p>AEGIS PROTOCOL v1.4 - "Firewall" | System Status: <span className="text-green-400">NOMINAL</span></p>
+                <p>AEGIS PROTOCOL v1.5 - "Firewall" | System Status: <span className="text-green-400">NOMINAL</span></p>
             </footer>
         </div>
     </div>

--- a/src/database.js
+++ b/src/database.js
@@ -24,7 +24,18 @@ const missionsData = [
       { id: 'ex_dbalr', name: 'Dumbbell Bent Arm Lateral Raise', type: 'weight_reps', targetSets: 3, targetReps: '15-20', previous: '8kg x 15-20 reps' },
       { id: 'ex_dk', name: 'Dumbbell Kickback', type: 'weight_reps', targetSets: 4, targetReps: '10-15', previous: '8-12.5kg x 10-15 reps' },
       { id: 'ex_dpu', name: 'Deep Push Up (hands on DBs)', type: 'reps_only', targetSets: 3, targetReps: 'max', previous: 'Body-weight x max reps' },
-      { id: 'ex_bbp', name: 'Barbell Bench Press', type: 'weight_reps', targetSets: 3, targetReps: '8-10', previous: '50-55kg x 8-10 reps' },
+      {
+        id: 'ex_bbp',
+        name: 'Barbell Bench Press',
+        type: 'weight_reps',
+        targetSets: 3,
+        targetReps: '8-10',
+        previous: '50-55kg x 8-10 reps',
+        alternatives: [
+          { id: 'ex_dbp', name: 'Dumbbell Bench Press', penalty: -5 },
+          { id: 'ex_dpu', name: 'Deep Push Up (hands on DBs)', penalty: -10 }
+        ]
+      },
       { id: 'ex_kte', name: 'Kettlebell Triceps Extension', type: 'weight_reps', targetSets: 2, targetReps: '10-12', previous: '8-12kg x 10-12 reps' },
     ],
   },
@@ -53,7 +64,18 @@ const missionsData = [
     xp: 3000,
     cCredBonus: 75,
     exercises: [
-      { id: 'ex_fs', name: 'Full Squat (barbell)', type: 'weight_reps', targetSets: 3, targetReps: '8-10', previous: '50kg x 8-10 reps' },
+      {
+        id: 'ex_fs',
+        name: 'Full Squat (barbell)',
+        type: 'weight_reps',
+        targetSets: 3,
+        targetReps: '8-10',
+        previous: '50kg x 8-10 reps',
+        alternatives: [
+          { id: 'ex_gs', name: 'Goblet Squat (KB/DB)', penalty: -5 },
+          { id: 'ex_bw_squat', name: 'Bodyweight Squat', penalty: -10 }
+        ]
+      },
       { id: 'ex_dl', name: 'Deadlift (conventional)', type: 'weight_reps', targetSets: 3, targetReps: '15-16', previous: '50kg x 15-16 reps' },
       { id: 'ex_brdl', name: 'Barbell Romanian Deadlift', type: 'weight_reps', targetSets: 3, targetReps: '12-15', previous: '50kg x 12-15 reps' },
       { id: 'ex_gs', name: 'Goblet Squat (KB/DB)', type: 'weight_reps', targetSets: 3, targetReps: '15-20', previous: '12.5-16kg x 15-20 reps' },


### PR DESCRIPTION
## Summary
- add alternative exercises in database
- bump UI version text to v1.5

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6884e854049c832f895e06713d1a6f87