### PR TITLE
Add npm setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ A single page workout tracker built with React and TailwindCSS. The
 application runs entirely in the browser so it can be hosted directly
 through GitHub Pages.
 
-To view the site locally open `index.html` in your browser. When
-pushing to GitHub enable GitHub Pages in the repository settings and
-point it at the `main` branch to publish the site.
+To view the site locally open `index.html` in your browser. If you prefer
+to serve the project from a local web server run `npm install` once and
+then `npm start`. When pushing to GitHub enable GitHub Pages in the
+repository settings and point it at the `main` branch to publish the
+site.
 
 ## v1.1 Update
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cyber-warrior",
+  "version": "1.0.0",
+  "description": "Cyber Warrior workout tracker - static site",
+  "scripts": {
+    "start": "serve -s ."
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "serve": "^14.2.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add basic `package.json` and dev server via `serve`
- ignore `node_modules` and lock file
- document new npm usage in README

## Testing
- `npm install`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688607d083f0832f96c05b2641e9cb5b