### PR TITLE
Fix unified index runtime

### DIFF
--- a/src/apex/WorkoutLoggerApex.js
+++ b/src/apex/WorkoutLoggerApex.js
@@ -1,7 +1,12 @@
-import React, { useState, useEffect } from 'react';
+// This component renders the workout logger used by both the
+// Sleeper and AEGIS interfaces. It relies on the global React
+// instance provided in index.html so we don't import React as a
+// module. The component is attached to the `window` object at the
+// bottom of the file for use in inline Babel scripts.
+const { useState, useEffect } = React;
 
 // Parent component manages all logged sets across exercises.
-export default function WorkoutLoggerApex({ directive, stats }) {
+function WorkoutLoggerApex({ directive, stats }) {
   // loggedSets: { [exercise.id]: Array<{ set: number, weight: number, reps: number, time: number }> }
   const [loggedSets, setLoggedSets] = useState({});
   const [expandedExerciseId, setExpandedExerciseId] = useState(null);
@@ -201,3 +206,5 @@ function SetRow({ setNumber, exercise, isLogged, defaults, onToggle }) {
     </tr>
   );
 }
+
+window.WorkoutLoggerApex = WorkoutLoggerApex;

--- a/src/features/AwakeningEvent.js
+++ b/src/features/AwakeningEvent.js
@@ -1,4 +1,7 @@
-import React, { useState, useEffect } from 'react';
+// AwakeningEvent renders the brief glitch animation that plays when the
+// user crosses the resonance threshold. It uses the global React object
+// exposed in index.html, so we don't import React as a module.
+const { useState, useEffect } = React;
 
 // This component renders the "glitch" awakening animation. Display it
 // fullscreen when the RESONANCE_SYNC bar reaches 100% and handle the
@@ -92,4 +95,4 @@ const AwakeningEvent = ({ onComplete }) => {
   }
 };
 
-export default AwakeningEvent;
+window.AwakeningEvent = AwakeningEvent;

--- a/unified/App.js
+++ b/unified/App.js
@@ -1,7 +1,11 @@
-import React, { useState, useEffect, createContext, useContext } from 'react';
-import ReactDOM from 'react-dom';
-import WorkoutLoggerApex from '../src/apex/WorkoutLoggerApex.js';
-import AwakeningEvent from '../src/features/AwakeningEvent.js';
+// The unified app is executed directly in the browser without a
+// bundler. React and ReactDOM are loaded via CDN which exposes them
+// as globals. Additional components are included through separate
+// Babel scripts and attached to `window`.
+const { useState, useEffect, createContext, useContext } = React;
+const { render } = ReactDOM;
+const WorkoutLoggerApex = window.WorkoutLoggerApex;
+const AwakeningEvent = window.AwakeningEvent;
 
 // Use the existing global databases provided by the project
 const sleeperRoutines = window.sleeperRoutines || [];
@@ -197,6 +201,5 @@ function App() {
   );
 }
 
-ReactDOM.render(<App />, document.getElementById('root'));
-
-export default App;
+render(<App />, document.getElementById('root'));
+window.App = App;

--- a/unified/index.html
+++ b/unified/index.html
@@ -11,8 +11,11 @@
 
   <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <script type="text/babel" src="../sleeper/sleeper-database.js"></script>
   <script type="text/babel" src="../src/database.js"></script>
-  <script type="module" src="./App.js"></script>
+  <script type="text/babel" src="../src/apex/WorkoutLoggerApex.js"></script>
+  <script type="text/babel" src="../src/features/AwakeningEvent.js"></script>
+  <script type="text/babel" src="./App.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- adapt `WorkoutLoggerApex.js` and `AwakeningEvent.js` for browser runtime
- load global React components for the unified app
- include Babel transformation in the unified index

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688669aa6004832fa7305a9ca79372a3