### PR TITLE
Fix unified app initialization

### DIFF
--- a/unified/App.js
+++ b/unified/App.js
@@ -13,7 +13,7 @@ const aegisDirectives = window.missionsData || [];
 
 const AppContext = createContext();
 
-export const AppProvider = ({ children }) => {
+const AppProvider = ({ children }) => {
   const [hasAwakened, setHasAwakened] = useState(() => {
     return localStorage.getItem('aegis_hasAwakened') === 'true';
   });
@@ -32,7 +32,7 @@ export const AppProvider = ({ children }) => {
   );
 };
 
-export const useAppContext = () => useContext(AppContext);
+const useAppContext = () => useContext(AppContext);
 
 // Helper icons used in the UI
 const HomeIcon = () => (


### PR DESCRIPTION
## Summary
- remove `export` keywords from `AppProvider` and `useAppContext`

The unified app relied on inline Babel transforms which emit CommonJS `exports`. Because `exports` is undefined when loading scripts directly in the browser, the page failed to initialize. By defining these helpers without module exports, the site now loads correctly on GitHub Pages.

## Testing
- `npm install`
- `npm start` *(confirm server launches)*

------
https://chatgpt.com/codex/tasks/task_e_68866b93c670832fb63408bd75692394