### PR TITLE
Fix browser build by removing ES modules

### DIFF
--- a/src/apex/index.html
+++ b/src/apex/index.html
@@ -10,6 +10,6 @@
   <div id="root"></div>
   <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
-  <script type="module" src="./index.js"></script>
+    <script type="text/babel" src="./index.js"></script>
 </body>
 </html>

--- a/src/apex/index.js
+++ b/src/apex/index.js
@@ -1,9 +1,6 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import WorkoutLoggerApex from './WorkoutLoggerApex.js';
-import { mockDirective, mockSessionStats } from './mockData.js';
+const { render } = ReactDOM;
 
-ReactDOM.render(
-  <WorkoutLoggerApex directive={mockDirective} stats={mockSessionStats} />,
+render(
+  <WorkoutLoggerApex directive={window.mockDirective} stats={window.mockSessionStats} />,
   document.getElementById('root')
 );

--- a/src/apex/mockData.js
+++ b/src/apex/mockData.js
@@ -1,4 +1,5 @@
-export const mockDirective = {
+// Mock data used by the Apex demo. Expose on window so scripts can access
+window.mockDirective = {
   title: 'SYSTEM DIRECTIVE: PUSH PROTOCOL',
   exercises: [
     { id: 'ex_dbp', name: 'Dumbbell Bench Press', type: 'weight_reps', targetSets: 3, previous: ['12.5kg x 22', '12.5kg x 20', '12.5kg x 18'], modifier: 'x2' },
@@ -8,7 +9,7 @@ export const mockDirective = {
   ],
 };
 
-export const mockSessionStats = {
+window.mockSessionStats = {
   time: '00:15:32',
   volume: '4500kg',
   cCreds: 15,


### PR DESCRIPTION
## Summary
- update the Apex demo scripts to avoid ES module exports
- load the Apex demo entry with Babel

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68866cce0ddc832fa746c6e4783bde72