### PR TITLE
Add login streak tracking and rewards

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,19 @@ const getInitialState = () => {
   if (savedData) {
     const data = JSON.parse(savedData);
     if (data.operator && !data.operator.xpMultiplier) data.operator.xpMultiplier = 1;
+    const operator = data.operator || { id: `#${Math.random().toString(16).substr(2,6).toUpperCase()}`, ...initialOperatorData };
+    const today = new Date().toISOString().slice(0,10);
+    if(!operator.lastLoginDate){
+      operator.lastLoginDate = today;
+      operator.currentStreak = 1;
+    } else {
+      const diff = Math.floor((new Date(today) - new Date(operator.lastLoginDate)) / 86400000);
+      if(diff === 1) operator.currentStreak = (operator.currentStreak || 0) + 1;
+      else if(diff > 1) operator.currentStreak = 1;
+      operator.lastLoginDate = today;
+    }
     return {
-      operator: data.operator || { id: `#${Math.random().toString(16).substr(2,6).toUpperCase()}`, ...initialOperatorData },
+      operator,
       history: data.history || [],
       resonance: data.resonance || 0,
       awakened: typeof data.awakened === 'boolean' ? data.awakened : awakenedFlag,
@@ -39,6 +50,8 @@ const getInitialState = () => {
     operator: {
       id: `#${Math.random().toString(16).substr(2, 6).toUpperCase()}`,
       ...initialOperatorData,
+      lastLoginDate: new Date().toISOString().slice(0,10),
+      currentStreak: 1,
     },
     history: [],
     resonance: 0,
@@ -86,11 +99,13 @@ const BBSHeader = ({ operator, onNav, resonance, awakened }) => {
             <div>LEVEL: {operator.level}</div>
             <div>XP: {operator.xp}</div>
             <div>C-Creds: {operator.cCreds}c</div>
+            <div>UPLINK_STREAK: {operator.currentStreak}d</div>
           </>
         ) : (
           <>
             <div>User ID: {operator.id}</div>
             <div>System Integrity: {operator.systemIntegrity}</div>
+            <div>Streak: {operator.currentStreak}d</div>
           </>
         )}
       </div>
@@ -179,6 +194,10 @@ const OperatorProfile = ({ operator, onNav, onAddResonance, onForceAwakening, on
             <div>
                 <p className="text-green-400">C-CREDS:</p>
                 <p className="ml-4 text-white">{operator.cCreds}c</p>
+            </div>
+            <div>
+                <p className="text-green-400">UPLINK_STREAK:</p>
+                <p className="ml-4 text-white">{operator.currentStreak}d</p>
             </div>
             </>) }
             <div>
@@ -618,6 +637,14 @@ function App() {
   const [showAwakening, setShowAwakening] = React.useState(false);
 
   React.useEffect(() => { setTimeout(() => setIsLoading(false), 1500); }, []);
+
+  React.useEffect(() => {
+    setOperator(prev => {
+      const { updated, message } = RewardSystem.checkStreakBonus(prev);
+      if(message) alert(message);
+      return updated;
+    });
+  }, []);
 
   React.useEffect(() => {
     const appData = { operator, history: workoutHistory, resonance, awakened };

--- a/src/database.js
+++ b/src/database.js
@@ -15,6 +15,8 @@ window.initialOperatorData = {
   dataFragments: 0,
   augments: ['Stock Chassis Mk I'],
   inventory: [],
+  currentStreak: 0,
+  lastLoginDate: null,
 };
 
 window.missionsData = [

--- a/systems/RewardSystem.js
+++ b/systems/RewardSystem.js
@@ -13,5 +13,17 @@
     }
     return { updated, message };
   }
-  global.RewardSystem = { awardFlawlessExecution, rollDataSpike };
+
+  function checkStreakBonus(operator){
+    const milestones = {7: 20, 30: 50, 100: 150};
+    const bonus = milestones[operator.currentStreak] || 0;
+    if(bonus > 0){
+      return {
+        updated: { ...operator, cCreds: operator.cCreds + bonus },
+        message: `// STREAK BONUS ACHIEVED! +${bonus} C-Creds`
+      };
+    }
+    return { updated: operator, message: null };
+  }
+  global.RewardSystem = { awardFlawlessExecution, rollDataSpike, checkStreakBonus };
 })(window);


### PR DESCRIPTION
## Summary
- track login streak in `initialOperatorData`
- add `checkStreakBonus` helper
- persist/update streak data and show it in UI

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68869d02c8bc832faaaf498168b8faca