### PR TITLE
Restore debug functionality in unified view

### DIFF
--- a/unified/index.html
+++ b/unified/index.html
@@ -10,6 +10,11 @@
   <div id="overlay" class="fixed inset-0 z-50 hidden"></div>
   <iframe id="sleeperFrame" src="../sleeper/" class="w-full h-screen border-0"></iframe>
   <iframe id="aegisFrame" src="../index.html" class="w-full h-screen border-0 hidden"></iframe>
+  <div id="debugMenu" class="fixed bottom-12 right-2 bg-black border border-green-500 p-2 text-xs space-y-1 z-50 hidden">
+    <button id="forceAwakenBtn" class="block w-full border border-green-500">[FORCE AWAKENING]</button>
+    <button id="resetSleeperBtn" class="block w-full border border-green-500">[RESET TO SLEEPER]</button>
+  </div>
+  <button id="debugToggle" class="fixed bottom-2 right-2 z-50 border border-green-500 bg-black/70 text-green-400 px-2 py-1 text-xs">[DBG]</button>
 
   <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
@@ -52,6 +57,26 @@
     } else {
       showFrame(sleeperFrame);
     }
+
+    const debugToggle = document.getElementById('debugToggle');
+    const debugMenu = document.getElementById('debugMenu');
+    const forceBtn = document.getElementById('forceAwakenBtn');
+    const resetBtn = document.getElementById('resetSleeperBtn');
+
+    debugToggle.addEventListener('click', () => {
+      debugMenu.classList.toggle('hidden');
+    });
+
+    forceBtn.addEventListener('click', () => {
+      debugMenu.classList.add('hidden');
+      startAwakening();
+    });
+
+    resetBtn.addEventListener('click', () => {
+      localStorage.removeItem('hasAwakened');
+      showFrame(sleeperFrame);
+      debugMenu.classList.add('hidden');
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add debug menu and toggle button to unified page
- wire up JS handlers for forcing awakening and resetting

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6886a4212b98832f8f8c321d985ea186