### PR TITLE
Enable live Resonance Engine tick

### DIFF
--- a/index.html
+++ b/index.html
@@ -663,6 +663,20 @@ function App() {
   }, []);
 
   React.useEffect(() => {
+    const engineTickInterval = setInterval(() => {
+      setOperator(prev => {
+        const { charge, cCredsToAdd } = EngineSystem.updateEngineOnTick({ ...prev.engine });
+        return {
+          ...prev,
+          cCreds: prev.cCreds + cCredsToAdd,
+          engine: { ...prev.engine, charge, lastUpdated: Date.now() }
+        };
+      });
+    }, 5000);
+    return () => clearInterval(engineTickInterval);
+  }, []);
+
+  React.useEffect(() => {
     const appData = { operator, history: workoutHistory, resonance, awakened };
     localStorage.setItem('aegis_app_data', JSON.stringify(appData));
   }, [operator, workoutHistory, resonance, awakened]);

--- a/systems/EngineSystem.js
+++ b/systems/EngineSystem.js
@@ -34,6 +34,19 @@
     return { newCharge, cCredsGenerated };
   }
 
-  global.EngineSystem = { calculateBaseline, calculateChargeGained, calculateOfflineProgress };
+  function updateEngineOnTick(engineState){
+    const secondsPerTick = 5;
+    const hoursPerTick = secondsPerTick / 3600;
+
+    const chargeDecayed = hoursPerTick * engineState.components.field.decayRate;
+    const newCharge = Math.max(0, engineState.charge - chargeDecayed);
+
+    const avgCharge = (engineState.charge + newCharge) / 2;
+    const cCredsGenerated = hoursPerTick * (avgCharge * engineState.components.resonator.multiplier);
+
+    return { charge: newCharge, cCredsToAdd: cCredsGenerated };
+  }
+
+  global.EngineSystem = { calculateBaseline, calculateChargeGained, calculateOfflineProgress, updateEngineOnTick };
 })(window);
 


### PR DESCRIPTION
## Summary
- add `updateEngineOnTick` helper in `EngineSystem`
- set up an interval in `App` to decay charge and accumulate C-Creds every 5s

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688767bbc328832f9c1817f8e8175113